### PR TITLE
Jasond1016 patch 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -279,7 +279,7 @@
     "@opentelemetry/resources": "^2.2.0",
     "@opentelemetry/sdk-metrics": "^2.2.0",
     "@opentelemetry/winston-transport": "^0.19.0",
-    "@react-pdf/renderer": "^4.3.2",
+    "@react-pdf/renderer": "4.4.1",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
     "@saintno/comfyui-sdk": "^0.2.49",

--- a/package.json
+++ b/package.json
@@ -537,6 +537,7 @@
       "ffmpeg-static"
     ],
     "overrides": {
+      "@react-pdf/image": "3.0.4",
       "@types/react": "19.2.13",
       "better-auth": "1.4.6",
       "better-call": "1.1.8",


### PR DESCRIPTION
>  ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/@react-pdf%2Fsvg: Not Found - 404
This error happened while installing the dependencies of @react-pdf/renderer@4.5.0
 at @react-pdf/layout@4.6.0
 at @react-pdf/image@3.1.0
@react-pdf/svg is not in the npm registry, or you have no permission to fetch it.
No authorization header was set for the request.
Error: Process completed with exit code 1.

fix patch for this